### PR TITLE
Abstract Factory pattern

### DIFF
--- a/GOF-design-patterns/Factory.cs
+++ b/GOF-design-patterns/Factory.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GOF_design_patterns
+{
+    // Real life example
+    // In a restaurant, based on customer inputs, a chef varies the taste of dishes to make the final products.
+    public interface IAnimal
+    {
+        void Speak();
+        void Action();
+    }
+
+    public class Dog : IAnimal
+    {
+        public void Speak()
+        {
+            Console.WriteLine("Dog says: Bow-Wow.");
+        }
+        public void Action()
+        {
+            Console.WriteLine("Dogs prefer barking...\n");
+        }
+    }
+
+    public class Tiger : IAnimal
+    {
+        public void Speak()
+        {
+            Console.WriteLine("Tiger syas : Halum.");
+        }
+        public void Action()
+        {
+            Console.WriteLine("Tigers prefer hunting...\n");
+        }
+    }
+
+    public abstract class IAnimalFactory
+    {
+        public IAnimal MakeAnimal()
+        {
+            IAnimal animal = CreateAnimal();
+            animal.Speak();
+            animal.Action();
+            return animal;
+        }
+        public abstract IAnimal CreateAnimal();
+    }
+
+    public class DogFactory : IAnimalFactory
+    {
+        public override IAnimal CreateAnimal()
+        {
+            return new Dog();
+        }
+    }
+
+    public class TigerFactory : IAnimalFactory
+    {
+        public override IAnimal CreateAnimal()
+        {
+            return new Tiger();
+        }
+    }
+    
+    class FactoryProgram
+    {
+        static void FactoryMain(string[] args)
+        {
+            IAnimalFactory tigerFactory = new TigerFactory();
+            IAnimal aTiger = tigerFactory.MakeAnimal();
+            //IAnimal aTiger = tigerFactory.CreateAnimal();
+            //aTiger.Speak();
+            //aTiger.Action();
+
+            IAnimalFactory dogFactory = new DogFactory();
+            IAnimal aDog = dogFactory.MakeAnimal();
+            //IAnimal aDog = DogFactory.CreateAnimal();
+            //aDog.Speak();
+            //aDog.Action();
+            Console.ReadKey();
+        }
+    }
+}

--- a/GOF-design-patterns/GOF-design-patterns.csproj
+++ b/GOF-design-patterns/GOF-design-patterns.csproj
@@ -44,6 +44,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Builder.cs" />
+    <Compile Include="Factory.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Prototype.cs" />

--- a/GOF-design-patterns/Program.cs
+++ b/GOF-design-patterns/Program.cs
@@ -6,95 +6,126 @@ using System.Threading.Tasks;
 
 namespace GOF_design_patterns
 {
-    // R.L. exp.
-    // In a restaurant, based on customer inputs, a chef varies the taste of dishes to make the final products.
-    public interface IAnimal
+    public interface IDog
     {
         void Speak();
         void Action();
     }
-    public class Dog : IAnimal
+    public interface ITiger
     {
-        public void Speak()
-        {
-            Console.WriteLine("Dog says: Bow-Wow.");
-        }
-        public void Action()
-        {
-            Console.WriteLine("Dogs prefer barking...\n");
-        }
+        void Speak();
+        void Action();
     }
-    public class Tiger : IAnimal
-    {
-        public void Speak()
-        {
-            Console.WriteLine("Tiger syas : Halum.");
-        }
-        public void Action()
-        {
-            Console.WriteLine("Tigers prefer hunting...\n");
-        }
-    }
-    public abstract class IAnimalFactory
-    {
-        //Remember the GoF definition which says "....Factory method lets a class
-        //defer instantiation to subclasses." Following method will create a Tiger
-        //or Dog But at this point it does not know whether it will get a Dog or a
-        //Tiger. It will be decided by the subclasses i.e.DogFactory or TigerFactory.
-        //So, the following method is acting like a factory (of creation).
 
-        public IAnimal MakeAnimal()
-        {
-            Console.WriteLine("\n IAnimalFactory.MakeAnimal()-You cannot ignore parent rules.");
-            /* At this point, it doens't know whether it will get a Dog or a Tiger.
-               It will be decided by the subclasses i.e.DogFactory or TigerFactory.
-               But it knows that it will speak and it will have a preferred way of Action.*/
-            IAnimal animal = CreateAnimal();
-            animal.Speak();
-            animal.Action();
-            return animal;
-        }
-        // So, the following method is acting like a factory (of creation).
-        public abstract IAnimal CreateAnimal();
-    }
-    public class DogFactory : IAnimalFactory
+    #region Wild Animal collections
+    class WildDog : IDog
     {
-        public override IAnimal CreateAnimal()
+        public void Speak()
         {
-            return new Dog();
+            Console.WriteLine("Wild Dog says: Bow-Wow.");
+        }
+        public void Action()
+        {
+            Console.WriteLine("Wild Dogs prefer to roam freely in jungles.\n");
         }
     }
-    public class TigerFactory : IAnimalFactory
+
+    class WildTiger : ITiger
     {
-        public override IAnimal CreateAnimal()
+        public void Speak()
         {
-            return new Tiger();
+            Console.WriteLine("Wild Tiger says: Halum.");
+        }
+        public void Action()
+        {
+            Console.WriteLine("Wild Tigers prefer hunting in jungles.\n");
         }
     }
+    #endregion
+
+    #region Pet Animal collections
+    class PetDog : IDog
+    {
+        public void Speak()
+        {
+            Console.WriteLine("Pet Dog says: Bow-Wow.");
+        }
+        public void Action()
+        {
+            Console.WriteLine("Pet Dogs prefer to stay at home.\n");
+        }
+    }
+
+    class PetTiger : ITiger
+    {
+        public void Speak()
+        {
+            Console.WriteLine("Pet Tiger says: Halum.");
+        }
+        public void Action()
+        {
+            Console.WriteLine("Pet Tigers play in an animal circus.\n");
+        }
+    }
+    #endregion
+
+    // Abstract Factory
+    public interface IAnimalFactoryAbstract
+    {
+        IDog GetDog();
+        ITiger GetTiger();
+    }
+
+    // Concrete Factory-Wild Animal Factory
+    public class WildAnimalFactory : IAnimalFactoryAbstract
+    {
+        public IDog GetDog()
+        {
+            return new WildDog();
+        }
+        public ITiger GetTiger()
+        {
+            return new WildTiger();
+        }
+    }
+
+    // Concrete Factory-Pet Animal Factory
+    public class PetAnimalFactory : IAnimalFactoryAbstract
+    {
+        public IDog GetDog()
+        {
+            return new PetDog();
+        }
+
+        public ITiger GetTiger()
+        {
+            return new PetTiger();
+        }
+    }
+
     class Program
     {
         static void Main(string[] args)
         {
-            Console.WriteLine("***Factory pattern demo***\n");
-            // Creating a Tiger Factory
-            IAnimalFactory tigerFactory = new TigerFactory();
-            IAnimal aTiger = tigerFactory.MakeAnimal();
+            Console.WriteLine("***Abstract Factory Pattern Demo***\n");
+            // Making a wild dog through WildAnimalFactory
+            IAnimalFactoryAbstract wildAnimalFactory = new WildAnimalFactory();
+            IDog wildDog = wildAnimalFactory.GetDog();
+            wildDog.Speak();
+            wildDog.Action();
 
-            // Creating a tiger using the Factory Method
-            //IAnimal aTiger = tigerFactory.CreateAnimal();
-            //aTiger.Speak();
-            //aTiger.Action();
+            Console.WriteLine("*******");
+            IAnimalFactoryAbstract petAnimalFactory = new PetAnimalFactory();
+            IDog petDog = petAnimalFactory.GetDog();
+            petDog.Speak();
+            petDog.Action();
 
-            // Creating a DogFactory
-            IAnimalFactory dogFactory = new DogFactory();
-            IAnimal aDog = dogFactory.MakeAnimal();
+            // Making a pet tiger through PetAnimalFactory
+            ITiger petTiger = petAnimalFactory.GetTiger();
+            petTiger.Speak();
+            petTiger.Action();
 
-            // Creating a dog using the Factory Method
-            //IAnimal aDog = dogFactory.CreateAnimal();
-            //aDog.Speak();
-            //aDog.Action();
-
-            Console.ReadKey();
+            Console.ReadLine();
         }
     }
 }


### PR DESCRIPTION
An abstract factory is called a factory of factories. In this pattern, you provide a way to encapsulate a group of individual factories that have a common theme. In this process, you do not mention or specify their concrete classes.
This pattern helps you to interchange specific implementations without changing the code that uses them, even at runtime. However, it may result in unnecessary complexity and extra work. Even debugging becomes tough in some cases.